### PR TITLE
Updated main-navBar-entryPoints border radius

### DIFF
--- a/user.css
+++ b/user.css
@@ -121,7 +121,7 @@
   padding: 0 12px;
   box-sizing: content-box;
   transition: 350ms background-color;
-  border-radius: var(--border-radius) var(--border-radius) 0 0;
+  border-radius: var(--border-radius);
   margin: 24px 12px 0 12px;
   background-color: rgba(0, 0, 0, 0.1);
 }


### PR DESCRIPTION
I know this was probably intentional, but why is it different than the border-radius of the playlists for example?
For consistency, I think it looks better.

| Before | Now |
| :---------: | :---------: |
| ![image](https://user-images.githubusercontent.com/19473034/142608451-589ba7d0-a068-44f4-a82d-ea6eeae01afd.png)  | ![image](https://user-images.githubusercontent.com/19473034/142608345-bea36a42-be5c-485a-8dce-ffd445fea0ae.png)  |