### PR TITLE
Add install and uninstall scripts for Unix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ![Banner](https://nyri4.github.io/Comfy-spicetify/assets/banner.png)
---- 
+
+---
 
 ![Preview](https://nyri4.github.io/Comfy-spicetify/assets/preview.png)
 
@@ -7,44 +8,35 @@
 
 ---
 
+#### Automatic Install - macOS and Linux Only
+
+This will install the theme and accompanying extension automatically.
+
+In **Bash**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/NYRI4/Comfy-spicetify/main/install.sh | sh
+```
+
+#### Manual Install
+
 Go into your `Themes` folder in `.spicetify` then do :
+
 ```sh
 git clone https://github.com/NYRI4/Comfy-spicetify
 ```
 
-#### Windows
-In **Powershell**:
-```powershell
+Run:
+
+```sh
 spicetify config current_theme Comfy-spicetify
 spicetify config inject_css 1 replace_colors 1 overwrite_assets 1
 spicetify apply
 ```
 
-#### macOS and Linux
-In **Bash**:
-```bash
-spicetify config current_theme Comfy-spicetify
-spicetify config inject_css 1 replace_colors 1 overwrite_assets 1
-spicetify apply
-```
+If you want to have the image header on a playlist, move the `Comfy.js` file to the `Extensions` folder and run:
 
-If you want to have the image header on a playlist, move the `Comfy.js` file to the `Extensions` folder and do :
-
-#### Windows
-In **Powershell**:
-```powershell
-cd "$(spicetify -c | Split-Path)\Themes\Comfy-spicetify"
-Copy-Item Comfy.js ..\..\Extensions
-spicetify config extensions Comfy.js
-spicetify apply
-```
-
-#### macOS and Linux
-In **Bash**:
-```bash
-cd "$(dirname "$(spicetify -c)")/Themes/Comfy-spicetify"
-mkdir -p ../../Extensions
-cp Comfy.js ../../Extensions/.
+```sh
 spicetify config extensions Comfy.js
 spicetify apply
 ```
@@ -53,14 +45,14 @@ spicetify apply
 
 ---
 
-The theme part is now updating itself for users using the version of Spicetify equals or greater than `2.8.2`, however, for the extesnion part if you have issues with it : 
+The theme part is now updating itself for users using the version of Spicetify equals or greater than `2.8.2`, however, for the extension part if you have issues with it :
 
 1. Go [here](https://nyri4.github.io/Comfy-spicetify/Comfy.js)
 2. Copy the whole code (sorry for the flashbang)
 3. Go into the Spicetify extension folder
 4. Open the `Comfy.js` file, paste the code and **save it**
-4. Afterwards, in a terminal, run `spicetify apply`
-5. Enjoy !
+5. Afterwards, in a terminal, run `spicetify apply`
+6. Enjoy !
 
 For the users that don't want to update Spicetify to the newest version, do the same with [this](https://nyri4.github.io/Comfy-spicetify/Comfy.js) and paste it in the `user.css` replacing the `@import`.
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -e
+
+echo "Downloading"
+# Setup directories to download to
+theme_dir="$(dirname "$(spicetify -c)")/Themes/Comfy"
+ext_dir="$(dirname "$(spicetify -c)")/Extensions"
+
+# Make directories if needed
+mkdir -p "${theme_dir}"
+mkdir -p "${ext_dir}"
+
+# Download latest tagged files into correct directories
+curl --progress-bar --output "${theme_dir}/color.ini" "https://raw.githubusercontent.com/NYRI4/Comfy-spicetify/main/color.ini"
+curl --progress-bar --output "${theme_dir}/user.css" "https://raw.githubusercontent.com/NYRI4/Comfy-spicetify/main/user.css"
+curl --progress-bar --output "${ext_dir}/Comfy.js" "https://raw.githubusercontent.com/NYRI4/Comfy-spicetify/main/Comfy.js"
+
+echo "Applying theme"
+spicetify config extensions Comfy.js
+spicetify config current_theme Comfy color_scheme Comfy
+spicetify config inject_css 1 replace_colors 1 overwrite_assets 1
+spicetify apply
+
+echo "All done!"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+set -e
+
+cd "$(dirname "$(spicetify -c)")"
+
+echo "Uninstalling"
+cd "$(dirname "$(spicetify -c)")"
+spicetify config current_theme "SpicetifyDefault" color_scheme "green-dark" extensions Comfy.js-
+
+echo "Deleting files"
+while true; do
+    read -p "Do you wish to delete theme files? [y/n] " yn </dev/tty
+    case $yn in
+    [Yy]*)
+        theme_dir="$(dirname "$(spicetify -c)")/Themes/Comfy"
+        ext_dir="$(dirname "$(spicetify -c)")/Extensions"
+        rm -rf "$theme_dir"
+        # Use -f to ignore if missing
+        rm -f "$ext_dir/Comfy.js"
+        break
+        ;;
+    [Nn]*)
+        echo "Skipping deletion."
+        break
+        ;;
+    *) echo "Please answer yes or no." ;;
+    esac
+done
+
+spicetify apply


### PR DESCRIPTION
Thanks for making this theme, it looks really nice on my laptop! I noticed the install instructions required cloning the whole repository and looked overcomplicated for some less experienced users and thought a simple install script would be helpful.

I've added an install and uninstall script for macOS/Linux, I don't have as much experience with Powershell but I might try a Windows script later too.